### PR TITLE
Fix ImportError in python 3.4

### DIFF
--- a/overrides/__init__.py
+++ b/overrides/__init__.py
@@ -1,2 +1,2 @@
-from overrides import overrides
-from overrides import __VERSION__
+from overrides.overrides import overrides
+from overrides.overrides import __VERSION__


### PR DESCRIPTION
ImportError: cannot import name '**VERSION**'
